### PR TITLE
add browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "types": "index.d.ts",
   "main": "dynamic.cjs",
+  "browser": "./browser.mjs",
   "exports": {
     ".": {
       "browser": "./browser.mjs",


### PR DESCRIPTION
The readme says
> We're also making use of webpack's pseudo-standard of the "browser" flag for imports.

Which I think means a `browser` field in package.json, but it is not there yet.

This is part of me getting things to work with browserify & esmify. I should also patch esmify to work with `exports` field, but this seems like less work for now.