### PR TITLE
Add "types" to the package's "exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "main": "dynamic.cjs",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "browser": "./browser.mjs",
       "import": "./node.mjs",
       "require": "./node.cjs"


### PR DESCRIPTION
When importing this package using a newer version of TypeScript, with the settings `"module": "nodenext", "moduleResolution": "nodenext"`, TypeScript was not able to find the declarations file, because it was only checking the exports.

> error TS7016: Could not find a declaration file for module 'one-webcrypto'. '.../node_modules/one-webcrypto/node.mjs' implicitly has an 'any' type.
  There are types at '.../node_modules/one-webcrypto/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'one-webcrypto' library may need to update its package.json or typings.

This PR adds the declaration file to the package's exports, while keeping the "types" key for both older versions of TypeScript, and for the TS badge on NPM.

(FWIW, I was also able to work around this by adding the following to `tsconfig.json`, but this may be fragile: `"paths": {"one-webcrypto": "./node_modules/one-webcrypto/index.d.ts"}`)